### PR TITLE
Removed loading Twig's Debug extension

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,10 +6,6 @@ parameters:
     snowcap_core.paginator.template: ~
 
 services:
-    # Load twig debug
-    twig.extension.debug:
-        class: Twig_Extensions_Extension_Debug
-        tags: [ { name: 'twig.extension' } ]
     # Load twig dump
     twig.extension.dump:
         class: Twig_Extension_Debug


### PR DESCRIPTION
As it got deprecated & removed > https://github.com/fabpot/Twig-extensions/commit/c0ab818595338dd5569369bfce2552d02cec5d50
