### PR TITLE
NavigationRegistry should not use deprecated ContainerAware

### DIFF
--- a/Navigation/NavigationRegistry.php
+++ b/Navigation/NavigationRegistry.php
@@ -2,9 +2,13 @@
 
 namespace Snowcap\CoreBundle\Navigation;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class NavigationRegistry extends ContainerAware {
+class NavigationRegistry implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
     /**
      * @var array
      */


### PR DESCRIPTION
Use ContainerAwareInterface instead.
See http://api.symfony.com/3.0/Symfony/Component/DependencyInjection/ContainerAware.html